### PR TITLE
Bugfix/get noise fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ else (LINUX_BITNESS STREQUAL "32-BIT")
 endif (LINUX_BITNESS STREQUAL "32-BIT")
 
 set(ControlSim_CXX_FLAGS "${ControlSim_CXX_FLAGS} -std=c++0x")
-set(CMAKE_CXX_FLAGS "${ControlSim_CXX_FLAGS} -Wreturn-type")
+set(CMAKE_CXX_FLAGS "${ControlSim_CXX_FLAGS} -Wall")
 
 #########################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ else (LINUX_BITNESS STREQUAL "32-BIT")
 endif (LINUX_BITNESS STREQUAL "32-BIT")
 
 set(ControlSim_CXX_FLAGS "${ControlSim_CXX_FLAGS} -std=c++0x")
-set(CMAKE_CXX_FLAGS "${ControlSim_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${ControlSim_CXX_FLAGS} -Wreturn-type")
 
 #########################################################
 

--- a/src/control_simulators/bicycle.cpp
+++ b/src/control_simulators/bicycle.cpp
@@ -31,18 +31,18 @@ ConsistentVector Bicycle::dynamics(double time,
 
     // These below could be cached
     const double Mc = param_[M_C]; const double Md = param_[M_D]; const double Mp = param_[M_P];
-    const double L = param_[L]; const double Lsq = L*L;
-    const double C = param_[C];
+    const double L = param_[Bicycle::L]; const double Lsq = L*L;
+    const double C = param_[Bicycle::C];
     const double Lc = L-C;
     const double Dcm = param_[D_CM];
-    const double H = param_[H]; const double Hsq = H * H;
-    const double R = param_[R]; const double Rsq = R * R;
+    const double H = param_[Bicycle::H]; const double Hsq = H * H;
+    const double R = param_[Bicycle::R]; const double Rsq = R * R;
     const double M = Mc + Md; // cycle + tire mass
     const double Idc = Md * Rsq;
     const double Idv = 1.5 * Idc;
     const double Idl = 0.5 * Idc;
     const double Itot = inertial_ratio * Mc * Hsq  + Mp * (H + Dcm) * (H + Dcm);
-    const double V = param_[V]; const double Vsq = V*V;
+    const double V = param_[Bicycle::V]; const double Vsq = V*V;
     const double sigmadot = V/R;
 
     // extract parts of the control

--- a/src/control_simulators/interfaces/simulable.cpp
+++ b/src/control_simulators/interfaces/simulable.cpp
@@ -4,8 +4,6 @@
 #include <stdexcept>
 
 int Simulable::simulable_counter_ = 0;
-//double Simulable::integration_frequency_ = 0.1;
-//double Simulable::min_integration_dt_ = 1e-4;
 
 namespace {
   static const double RK4_INTEGRATION_CONSTANT = 1.0/6.0;
@@ -46,8 +44,7 @@ ConsistentVector Simulable::transition(double& time, double dt,
   checkStateSize(state);
   checkControlSize(control);
   ConsistentVector result;
-  double t0 = time;
-
+  
   // integration dt to be considered based on passed in dt
   double integration_dt = dt*integration_frequency_; 
   int num_steps = static_cast<int>(std::ceil(dt/integration_dt));
@@ -64,8 +61,6 @@ ConsistentVector Simulable::transition(double& time, double dt,
   for (int i = 0; i < num_steps; ++i) {
     result = rk4(time, integration_dt, result, control);
   }
-
-  assert(fabs(time - (t0 + dt)) < 1e-10);
 
   return result;
 }

--- a/src/control_simulators/interfaces/simulable.h
+++ b/src/control_simulators/interfaces/simulable.h
@@ -94,13 +94,13 @@ class Simulable {
   std::vector<double> param_;
   std::map<std::string, int> param_names_ = {};
 
-  MultivariateGaussian<double> gaussian_noise_;
-
   int id_;
   double time_;
   ConsistentVector state_;
   std::vector<ConsistentVector> all_states_;
   std::vector<ConsistentVector> all_controls_;
+
+  MultivariateGaussian<double> gaussian_noise_;
 };
 
 #endif

--- a/src/control_simulators/interfaces/simulable.h
+++ b/src/control_simulators/interfaces/simulable.h
@@ -32,8 +32,8 @@ class Simulable {
 				      const ConsistentVector& control) const;
 
   // setters and getters for Gaussian noise 
-  const Eigen::MatrixXd& getNoiseCovariance() const { gaussian_noise_.getCovariance(); } 
-  const Eigen::VectorXd& getNoiseMean() const { gaussian_noise_.getMean(); } 
+  const Eigen::MatrixXd& getNoiseCovariance() const { return gaussian_noise_.getCovariance(); } 
+  const Eigen::VectorXd& getNoiseMean() const { return gaussian_noise_.getMean(); } 
   void setNoiseMean(const Eigen::VectorXd& mean) { gaussian_noise_.setMean(mean); } 
   void setNoiseCovariance(const Eigen::MatrixXd& covariance) { gaussian_noise_.setCovariance(covariance); } 
   

--- a/src/simulator_test/cartpole_sim_test.cpp
+++ b/src/simulator_test/cartpole_sim_test.cpp
@@ -47,8 +47,8 @@ int main(int argc, char* argv[]) {
 
   std::vector<ConsistentVector> states = cp.allStates();
 
-  for (int i = 0; i < states.size(); ++i) {
-    file << states[i].transpose() << std::endl;
+  for (const auto &state : states) {
+    file << state.transpose() << std::endl;
   }
 
   file.close();
@@ -72,8 +72,8 @@ int main(int argc, char* argv[]) {
 
   states = cp1.allStates();
   
-  for (int i = 0; i < states.size(); ++i) {
-    file << states[i].transpose() << std::endl;
+  for (const auto &state : states) {
+    file << state.transpose() << std::endl;
   }
 
   file.close();
@@ -94,8 +94,8 @@ int main(int argc, char* argv[]) {
 
   states = cp1.allStates();
 
-  for (int i = 0; i < states.size(); ++i) {
-    file << states[i].transpose() << std::endl;
+  for (const auto &state : states) {
+    file << state.transpose() << std::endl;
   }
 
   file.close();

--- a/src/simulator_test/pendulum_sim_test.cpp
+++ b/src/simulator_test/pendulum_sim_test.cpp
@@ -46,8 +46,8 @@ int main(int argc, char* argv[]) {
 
   std::vector<ConsistentVector> states = p.allStates();
 
-  for (int i = 0; i < states.size(); ++i) {
-    file << states[i].transpose() << std::endl;
+  for (const auto &state : states) {
+    file << state.transpose() << std::endl;
   }
 
   file.close();
@@ -71,8 +71,8 @@ int main(int argc, char* argv[]) {
 
   states = p1.allStates();
 
-  for (int i = 0; i < states.size(); ++i) {
-    file << states[i].transpose() << std::endl;
+  for (const auto &state : states) {
+    file << state.transpose() << std::endl;
   }
 
   file.close();
@@ -92,8 +92,8 @@ int main(int argc, char* argv[]) {
 
   states = p1.allStates();
 
-  for (int i = 0; i < states.size(); ++i) {
-    file << states[i].transpose() << std::endl;
+  for (const auto &state : states) {
+    file << state.transpose() << std::endl;
   }
 
   file.close();
@@ -106,3 +106,4 @@ int main(int argc, char* argv[]) {
 
   return 0;
 }
+


### PR DESCRIPTION
Segfault bug (Issue #1 ) was happening in c++ and python due to a return value not being set in getNoiseCovariance() call. This was fixed. 

Additionally, CMakeLists now has -Wall turned to help prevent such bugs from happening again ([See this stackoverflow](http://stackoverflow.com/questions/1610030/why-does-flowing-off-the-end-of-a-non-void-function-without-returning-a-value-no)). Other code is updated to remove warnings.

@webrot9 - Can you do a quick code review of the changes and then we can merge it.
